### PR TITLE
Fix projectile wall collisions

### DIFF
--- a/Source/UnrealSpaceInvaders/HostileProjectile.cpp
+++ b/Source/UnrealSpaceInvaders/HostileProjectile.cpp
@@ -42,7 +42,7 @@ void AHostileProjectile::OnOverlap(UPrimitiveComponent* OverlappedComponent,
     {
         return;
     }
-        if (OtherActor->IsA<APlayerShip>() || OtherComp->IsA<UBrushComponent>() || OtherComp->IsA<ATheWall>())
+        if (OtherActor->IsA<APlayerShip>() || OtherComp->IsA<UBrushComponent>() || OtherActor->IsA<ATheWall>())
     {
         Destroy();
     }

--- a/Source/UnrealSpaceInvaders/Projectile.cpp
+++ b/Source/UnrealSpaceInvaders/Projectile.cpp
@@ -32,7 +32,7 @@ void AProjectile::ProjectileOverlap(UPrimitiveComponent* OverlappedComponent,
                                     bool bFromSweep,
                                     const FHitResult& SweepResult)
 {
-	if (Cast<AHostile>(OtherActor) || Cast<UBrushComponent>(OtherComp) || Cast<ATheWall>(OtherComp))
+	if (Cast<AHostile>(OtherActor) || Cast<UBrushComponent>(OtherComp) || Cast<ATheWall>(OtherActor))
 	{
 		Destroy();
 	}


### PR DESCRIPTION
## Summary
- adjust projectile overlap checks so projectiles register hitting `ATheWall`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f5b4d4f788320899c328000df425d