### PR TITLE
Centralize projectile movement in WeaponComponent

### DIFF
--- a/Source/UnrealSpaceInvaders/Components/WeaponComponent.cpp
+++ b/Source/UnrealSpaceInvaders/Components/WeaponComponent.cpp
@@ -1,10 +1,14 @@
 #include "WeaponComponent.h"
 #include "Kismet/GameplayStatics.h"
+#include "GameFramework/ProjectileMovementComponent.h"
 
 UWeaponComponent::UWeaponComponent()
 {
     FireRate = 1.0f; // One shot per second
     ProjectileSpeed = 500.0f; // Projectile speed
+    ProjectileMaxSpeed = 500.0f;
+    bRotationFollowsVelocity = true;
+    ProjectileGravityScale = 0.0f;
     SpawnOffset = FVector(0.0f, 0.0f, 50.0f); // Offset from the actor's center
     bFireUpwards = true; // Firing upwards by default
 }
@@ -35,20 +39,27 @@ void UWeaponComponent::Fire()
 		return;
 	}
 
-	if (AActor* Owner = GetOwner())
-	{
-		FVector Direction = bFireUpwards ? FVector::UpVector : FVector::DownVector;
-		FVector SpawnLocation = Owner->GetActorLocation() + SpawnOffset;
-		AActor* SpawnedProjectile = GetWorld()->SpawnActor<AActor>(ProjectileClass, SpawnLocation, Direction.Rotation());
-		if (SpawnedProjectile)
-		{
-			UPrimitiveComponent* RootComponent = Cast<UPrimitiveComponent>(SpawnedProjectile->GetRootComponent());
-			if (RootComponent)
-			{
-				RootComponent->SetPhysicsLinearVelocity(Direction * ProjectileSpeed);
-			}
-		}
+        if (AActor* Owner = GetOwner())
+        {
+                FVector Direction = bFireUpwards ? FVector::UpVector : FVector::DownVector;
+                FVector SpawnLocation = Owner->GetActorLocation() + SpawnOffset;
+                AActor* SpawnedProjectile = GetWorld()->SpawnActor<AActor>(ProjectileClass, SpawnLocation, Direction.Rotation());
+                if (SpawnedProjectile)
+                {
+                        if (UProjectileMovementComponent* MoveComp = SpawnedProjectile->FindComponentByClass<UProjectileMovementComponent>())
+                        {
+                                MoveComp->Velocity = Direction * ProjectileSpeed;
+                                MoveComp->InitialSpeed = ProjectileSpeed;
+                                MoveComp->MaxSpeed = ProjectileMaxSpeed;
+                                MoveComp->bRotationFollowsVelocity = bRotationFollowsVelocity;
+                                MoveComp->ProjectileGravityScale = ProjectileGravityScale;
+                        }
+                        else if (UPrimitiveComponent* RootComponent = Cast<UPrimitiveComponent>(SpawnedProjectile->GetRootComponent()))
+                        {
+                                RootComponent->SetPhysicsLinearVelocity(Direction * ProjectileSpeed);
+                        }
+                }
 
-		OnFire.Broadcast();
-	}
+                OnFire.Broadcast();
+        }
 }

--- a/Source/UnrealSpaceInvaders/Components/WeaponComponent.h
+++ b/Source/UnrealSpaceInvaders/Components/WeaponComponent.h
@@ -29,8 +29,17 @@ public:
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Weapon")
 	FVector SpawnOffset;
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Weapon")
-	float ProjectileSpeed;
+        UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Weapon")
+        float ProjectileSpeed;
+
+        UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Weapon")
+        float ProjectileMaxSpeed;
+
+        UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Weapon")
+        bool bRotationFollowsVelocity;
+
+        UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Weapon")
+        float ProjectileGravityScale;
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Weapon")
 	bool bFireUpwards;

--- a/Source/UnrealSpaceInvaders/HostileProjectile.cpp
+++ b/Source/UnrealSpaceInvaders/HostileProjectile.cpp
@@ -12,9 +12,9 @@ AHostileProjectile::AHostileProjectile()
     ProjectileMesh = CreateDefaultSubobject<UStaticMeshComponent>(TEXT("ProjectileMesh"));
     ProjectileMovement = CreateDefaultSubobject<UProjectileMovementComponent>(TEXT("ProjectileMovementComponent"));
 
-    ensure(ProjectileCollisionCapsule);
-    ensure(ProjectileMesh);
-    ensure(ProjectileMovement);
+    check(ProjectileCollisionCapsule);
+    check(ProjectileMesh);
+    check(ProjectileMovement);
 
     SetRootComponent(ProjectileCollisionCapsule);
     ProjectileMesh->SetupAttachment(ProjectileCollisionCapsule);
@@ -23,26 +23,17 @@ AHostileProjectile::AHostileProjectile()
     ProjectileCollisionCapsule->SetCapsuleHalfHeight(40.0f);
     ProjectileCollisionCapsule->SetCapsuleRadius(22.0f);
     
-    ProjectileCollisionCapsule->OnComponentBeginOverlap.AddDynamic(this, &AHostileProjectile::OnOverlap);
-
-    ProjectileMovement->InitialSpeed = 1000.0f;
-    ProjectileMovement->MaxSpeed = 1000.0f;
-    ProjectileMovement->bRotationFollowsVelocity = true;
-    ProjectileMovement->ProjectileGravityScale = 0.0f;
+    ProjectileCollisionCapsule->OnComponentBeginOverlap.AddDynamic(this, &ThisClass::PlayerShipOverlap);
 }
 
-void AHostileProjectile::OnOverlap(UPrimitiveComponent* OverlappedComponent,
-                                    AActor* OtherActor,
-                                    UPrimitiveComponent* OtherComp,
-                                    int32 OtherBodyIndex,
-                                    bool bFromSweep,
-                                    const FHitResult& SweepResult)
+void AHostileProjectile::PlayerShipOverlap(UPrimitiveComponent* OverlappedComponent,
+                                           AActor* OtherActor,
+                                           UPrimitiveComponent* OtherComp,
+                                           int32 OtherBodyIndex,
+                                           bool bFromSweep,
+                                           const FHitResult& SweepResult)
 {
-    if (!OtherActor || OtherActor == this)
-    {
-        return;
-    }
-        if (OtherActor->IsA<APlayerShip>() || OtherComp->IsA<UBrushComponent>() || OtherActor->IsA<ATheWall>())
+    if (OtherActor && (OtherActor->IsA<APlayerShip>() || OtherComp->IsA<UBrushComponent>() || OtherActor->IsA<ATheWall>()))
     {
         Destroy();
     }

--- a/Source/UnrealSpaceInvaders/HostileProjectile.h
+++ b/Source/UnrealSpaceInvaders/HostileProjectile.h
@@ -26,11 +26,11 @@ protected:
 	UPROPERTY(EditDefaultsOnly)
 	TObjectPtr<UProjectileMovementComponent> ProjectileMovement;
 
-	UFUNCTION()
-	void OnOverlap(UPrimitiveComponent* OverlappedComponent,
-						   AActor* OtherActor,
-						   UPrimitiveComponent* OtherComp,
-	                       int32 OtherBodyIndex,
-	                       bool bFromSweep,
-	                       const FHitResult& SweepResult);
+        UFUNCTION()
+        void PlayerShipOverlap(UPrimitiveComponent* OverlappedComponent,
+                                                       AActor* OtherActor,
+                                                       UPrimitiveComponent* OtherComp,
+                               int32 OtherBodyIndex,
+                               bool bFromSweep,
+                               const FHitResult& SweepResult);
 };


### PR DESCRIPTION
## Summary
- remove movement settings from `HostileProjectile`
- control projectile movement via new properties in `WeaponComponent`
- update overlap function name in `HostileProjectile`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840b1d357c48320858d0e4d68c174d2