### PR TITLE
Fix player death on hostile projectile

### DIFF
--- a/Source/UnrealSpaceInvaders/Gameplay/PlayerShip.cpp
+++ b/Source/UnrealSpaceInvaders/Gameplay/PlayerShip.cpp
@@ -56,11 +56,15 @@ void APlayerShip::PlayerShipOverlap(UPrimitiveComponent* OverlappedComponent,
                                     bool bFromSweep,
                                     const FHitResult& SweepResult)
 {
-	if (Cast<AHostileProjectile>(OtherActor))
-	{
-		ShipMesh->SetVisibility(false);
-		PlayerDeath();
-	}
+       if (Cast<AHostileProjectile>(OtherActor))
+       {
+               Lives--;
+               if (Lives <= 0)
+               {
+                       ShipMesh->SetVisibility(false);
+                       PlayerDeath();
+               }
+       }
 }
 
 void APlayerShip::Move(const FInputActionValue& Value)
@@ -85,7 +89,10 @@ void APlayerShip::Attack(const FInputActionValue& Value)
 
 void APlayerShip::PlayerDeath()
 {
-	UGameplayStatics::OpenLevel(this, FName(*GetWorld()->GetName()), false);
+       if (APlayerController* PC = UGameplayStatics::GetPlayerController(this, 0))
+       {
+               PC->SetPause(true);
+       }
 }
 
 void APlayerShip::Reload()

--- a/Source/UnrealSpaceInvaders/Gameplay/PlayerShip.h
+++ b/Source/UnrealSpaceInvaders/Gameplay/PlayerShip.h
@@ -61,7 +61,11 @@ protected:
 
 	FTimerHandle ReloadTimerHandle;
 
-	bool CanAttack = true;
+        bool CanAttack = true;
+
+       /** Number of lives the player has. Decreases when hit by an enemy projectile. */
+       UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Player")
+       int32 Lives = 1;
 
 	float ReloadTime = 0.5;
 


### PR DESCRIPTION
## Summary
- track player lives
- pause the game once lives reach zero
- decrement lives when hit by hostile projectile

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840b51879088320afdfba875829afcf