### PR TITLE
Add difficulty scaling mechanic

### DIFF
--- a/Source/UnrealSpaceInvaders/AI/Hostile.cpp
+++ b/Source/UnrealSpaceInvaders/AI/Hostile.cpp
@@ -6,6 +6,7 @@
 #include "UnrealSpaceInvaders/Components/WeaponComponent.h"
 #include "UnrealSpaceInvaders/HostileProjectile.h"
 #include "UnrealSpaceInvaders/Projectile.h"
+#include "UnrealSpaceInvaders/UnrealSpaceInvadersGameModeBase.h"
 
 AHostile::AHostile()
 {
@@ -52,12 +53,16 @@ void AHostile::ProjectileOverlap(UPrimitiveComponent* OverlappedComponent,
                                  bool bFromSweep,
                                  const FHitResult& SweepResult)
 {
-	if (Cast<AProjectile>(OtherActor))
-	{
-		HostileDestroyFX();
-		DestroySound();
-		Destroy();
-	}
+        if (Cast<AProjectile>(OtherActor))
+        {
+                HostileDestroyFX();
+                DestroySound();
+               if (AUnrealSpaceInvadersGameModeBase* GM = GetWorld() ? GetWorld()->GetAuthGameMode<AUnrealSpaceInvadersGameModeBase>() : nullptr)
+               {
+                       GM->NotifyHostileDestroyed(this);
+               }
+                Destroy();
+        }
 	else if (Cast<UBrushComponent>(OtherComp))
 	{
 		ChangeMovementDirection();
@@ -97,8 +102,10 @@ void AHostile::ChangeMovementDirection()
 
 void AHostile::Move()
 {
-	const FVector NewLocation = GetActorLocation() + FVector(0.0, MoveDirection, 0.0);
-	SetActorLocation(NewLocation);
+       AUnrealSpaceInvadersGameModeBase* GM = GetWorld() ? GetWorld()->GetAuthGameMode<AUnrealSpaceInvadersGameModeBase>() : nullptr;
+       const float Multiplier = GM ? GM->DifficultyMultiplier : 1.0f;
+       const FVector NewLocation = GetActorLocation() + FVector(0.0, MoveDirection * MoveSpeed * Multiplier, 0.0);
+       SetActorLocation(NewLocation);
 }
 
 void AHostile::BeginFire()

--- a/Source/UnrealSpaceInvaders/AI/Hostile.h
+++ b/Source/UnrealSpaceInvaders/AI/Hostile.h
@@ -15,10 +15,15 @@ UCLASS()
 
 class UNREALSPACEINVADERS_API AHostile : public AActor
 {
-	GENERATED_BODY()
+        GENERATED_BODY()
 
 public:
-	AHostile();
+        AHostile();
+
+       UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Movement")
+       float MoveSpeed = 1.0f;
+
+       FORCEINLINE class UWeaponComponent* GetWeaponComponent() const { return WeaponComponent; }
 
 protected:
 	virtual void BeginPlay() override;

--- a/Source/UnrealSpaceInvaders/UnrealSpaceInvadersGameModeBase.cpp
+++ b/Source/UnrealSpaceInvaders/UnrealSpaceInvadersGameModeBase.cpp
@@ -1,2 +1,34 @@
 #include "UnrealSpaceInvadersGameModeBase.h"
+#include "Kismet/GameplayStatics.h"
+#include "AI/Hostile.h"
+
+AUnrealSpaceInvadersGameModeBase::AUnrealSpaceInvadersGameModeBase()
+{
+       DifficultyMultiplier = 1.0f;
+}
+
+void AUnrealSpaceInvadersGameModeBase::IncreaseDifficulty()
+{
+       DifficultyMultiplier += 0.1f;
+
+       TArray<AActor*> HostileActors;
+       UGameplayStatics::GetAllActorsOfClass(GetWorld(), AHostile::StaticClass(), HostileActors);
+
+       for (AActor* Actor : HostileActors)
+       {
+               if (AHostile* Hostile = Cast<AHostile>(Actor))
+               {
+                       Hostile->MoveSpeed *= 1.1f;
+                       if (UWeaponComponent* Weapon = Hostile->GetWeaponComponent())
+                       {
+                               Weapon->FireRate = FMath::Max(0.1f, Weapon->FireRate * 0.9f);
+                       }
+               }
+       }
+}
+
+void AUnrealSpaceInvadersGameModeBase::NotifyHostileDestroyed(AHostile* DestroyedHostile)
+{
+       // Custom logic could be added here such as scoring or triggering new waves
+}
 

--- a/Source/UnrealSpaceInvaders/UnrealSpaceInvadersGameModeBase.h
+++ b/Source/UnrealSpaceInvaders/UnrealSpaceInvadersGameModeBase.h
@@ -7,6 +7,17 @@
 UCLASS()
 class UNREALSPACEINVADERS_API AUnrealSpaceInvadersGameModeBase : public AGameModeBase
 {
-	GENERATED_BODY()
-	
+       GENERATED_BODY()
+
+public:
+       AUnrealSpaceInvadersGameModeBase();
+
+       UFUNCTION(BlueprintCallable, Category="Difficulty")
+       void IncreaseDifficulty();
+
+       void NotifyHostileDestroyed(class AHostile* DestroyedHostile);
+
+protected:
+       UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Difficulty")
+       float DifficultyMultiplier;
 };


### PR DESCRIPTION
## Summary
- implement difficulty multiplier in GameMode
- expose IncreaseDifficulty to tune active Hostile actors
- add MoveSpeed and accessor to Hostile
- scale hostile movement using multiplier
- notify game mode when a hostile is destroyed

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6841aca06be88320be00ebe01b4ca5c9