### PR TITLE
Fix property name conflict in Projectile

### DIFF
--- a/Source/UnrealSpaceInvaders/AI/Hostile.cpp
+++ b/Source/UnrealSpaceInvaders/AI/Hostile.cpp
@@ -134,7 +134,7 @@ void AHostile::ProjectileCheck()
         {
                 if (AProjectile* Projectile = Cast<AProjectile>(Actor))
                 {
-                        if (Projectile->Owner == EProjectileOwner::Hostile)
+                        if (Projectile->ProjectileOwner == EProjectileOwner::Hostile)
                         {
                                 ProjectilesArray.Add(Projectile);
                         }

--- a/Source/UnrealSpaceInvaders/Components/WeaponComponent.cpp
+++ b/Source/UnrealSpaceInvaders/Components/WeaponComponent.cpp
@@ -68,7 +68,7 @@ void UWeaponComponent::Fire()
 
                         if (AProjectile* P = Cast<AProjectile>(SpawnedProjectile))
                         {
-                                P->Owner = Cast<APlayerShip>(Owner) ? EProjectileOwner::Player : EProjectileOwner::Hostile;
+                                P->ProjectileOwner = Cast<APlayerShip>(Owner) ? EProjectileOwner::Player : EProjectileOwner::Hostile;
                         }
                 }
 

--- a/Source/UnrealSpaceInvaders/Gameplay/PlayerShip.cpp
+++ b/Source/UnrealSpaceInvaders/Gameplay/PlayerShip.cpp
@@ -61,7 +61,7 @@ void APlayerShip::PlayerShipOverlap(UPrimitiveComponent* OverlappedComponent,
 {
         if (AProjectile* Projectile = Cast<AProjectile>(OtherActor))
         {
-                if (Projectile->Owner == EProjectileOwner::Hostile)
+                if (Projectile->ProjectileOwner == EProjectileOwner::Hostile)
                 {
                         ShipMesh->SetVisibility(false);
                         PlayerDeath();

--- a/Source/UnrealSpaceInvaders/Projectile.cpp
+++ b/Source/UnrealSpaceInvaders/Projectile.cpp
@@ -37,14 +37,14 @@ void AProjectile::ProjectileOverlap(UPrimitiveComponent* OverlappedComponent,
                                     bool bFromSweep,
                                     const FHitResult& SweepResult)
 {
-        if (Owner == EProjectileOwner::Player)
+        if (ProjectileOwner == EProjectileOwner::Player)
         {
                 if (Cast<AHostile>(OtherActor) || Cast<UBrushComponent>(OtherComp) || Cast<ATheWall>(OtherActor))
                 {
                         Destroy();
                 }
         }
-        else if (Owner == EProjectileOwner::Hostile)
+        else if (ProjectileOwner == EProjectileOwner::Hostile)
         {
                 if (Cast<APlayerShip>(OtherActor) || Cast<UBrushComponent>(OtherComp) || Cast<ATheWall>(OtherActor))
                 {

--- a/Source/UnrealSpaceInvaders/Projectile.h
+++ b/Source/UnrealSpaceInvaders/Projectile.h
@@ -34,7 +34,7 @@ protected:
         TObjectPtr<UProjectileMovementComponent> ProjectileMovement;
 
         UPROPERTY(EditAnywhere)
-        EProjectileOwner Owner = EProjectileOwner::Player;
+        EProjectileOwner ProjectileOwner = EProjectileOwner::Player;
 
 	UFUNCTION()
 	void ProjectileOverlap(UPrimitiveComponent* OverlappedComponent,


### PR DESCRIPTION
## Summary
- rename `Owner` property to `ProjectileOwner` to avoid shadowing `AActor::Owner`
- update usages across gameplay, AI, and components

## Testing
- `g++ -c Source/UnrealSpaceInvaders/Projectile.cpp -o /tmp/projectile.o` *(fails: fatal error: CoreMinimal.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6841cae20a508320bae56f46cbf11513