### PR TITLE
Remove trailing whitespace

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,6 @@
+[*]
+trim_trailing_whitespace = true
+
 [*.{cpp,h}]
 
 # Naming convention rules (note: currently need to be ordered from more to less specific)

--- a/Source/UnrealSpaceInvaders/Environment/TheWall.cpp
+++ b/Source/UnrealSpaceInvaders/Environment/TheWall.cpp
@@ -14,7 +14,7 @@ void ATheWall::ConstructWall()
 	double Spacing = 10.0;
 	int32 Row;
 	int32 Column;
-	
+
 	for (Row = 0; Row < Count; Row++)
 	{
 		for (Column = 0; Column < Count; Column++)
@@ -29,7 +29,7 @@ void ATheWall::ConstructWall()
 					WallComponent->SetupAttachment(RootComponent);
 					WallComponent->SetRelativeTransform(
 						FTransform(FRotator::ZeroRotator, FVector(0.0, Column * Spacing, Row * Spacing),
-						           FVector(0.1, 0.1, 0.1)));						           
+						           FVector(0.1, 0.1, 0.1)));
 					WallComponent->RegisterComponent();
 					WallComponent->OnComponentBeginOverlap.AddDynamic(this, &ThisClass::WallOverlap);
 				}

--- a/Source/UnrealSpaceInvaders/Gameplay/PlayerShip.h
+++ b/Source/UnrealSpaceInvaders/Gameplay/PlayerShip.h
@@ -21,7 +21,7 @@ class UNREALSPACEINVADERS_API APlayerShip : public APawn
 	GENERATED_BODY()
 
 public:
-	
+
 	APlayerShip();
 
 	virtual void SetupPlayerInputComponent(class UInputComponent* PlayerInputComponent) override;

--- a/Source/UnrealSpaceInvaders/UnrealSpaceInvaders.Build.cs
+++ b/Source/UnrealSpaceInvaders/UnrealSpaceInvaders.Build.cs
@@ -5,7 +5,7 @@ public class UnrealSpaceInvaders : ModuleRules
 	public UnrealSpaceInvaders(ReadOnlyTargetRules Target) : base(Target)
 	{
 		PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
-	
+
                 PublicDependencyModuleNames.AddRange(new string[] { "Core", "CoreUObject", "Engine", "InputCore", "EnhancedInput", "Niagara", "UMG", "GameplayTasks" });
                 PrivateDependencyModuleNames.AddRange(new string[] { });
 	}

--- a/Source/UnrealSpaceInvaders/UnrealSpaceInvadersGameModeBase.cpp
+++ b/Source/UnrealSpaceInvaders/UnrealSpaceInvadersGameModeBase.cpp
@@ -33,6 +33,6 @@ void AUnrealSpaceInvadersGameModeBase::IncreaseDifficulty()
 void AUnrealSpaceInvadersGameModeBase::NotifyHostileDestroyed(AHostile* DestroyedHostile) // Custom logic could be added here such as scoring or triggering new waves
 {
 		IncreaseDifficulty();
-		       
+
 }
 


### PR DESCRIPTION
## Summary
- strip trailing whitespace across source files
- clean whitespace in TheWall.cpp, GameModeBase.cpp and PlayerShip.h
- enforce automatic whitespace trimming via `.editorconfig`

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6849d34d9b588320aef246f8a995e6d0