### PR TITLE
Implement score HUD widget

### DIFF
--- a/Source/UnrealSpaceInvaders/Components/ScoreComponent.cpp
+++ b/Source/UnrealSpaceInvaders/Components/ScoreComponent.cpp
@@ -15,5 +15,10 @@ void UScoreComponent::AddScore(float Amount)
 
 void UScoreComponent::ResetScore()
 {
-		ResetValue();
+                ResetValue();
+}
+
+float UScoreComponent::GetScore() const
+{
+                return CurrentValue;
 }

--- a/Source/UnrealSpaceInvaders/Components/ScoreComponent.h
+++ b/Source/UnrealSpaceInvaders/Components/ScoreComponent.h
@@ -15,6 +15,9 @@ public:
 		UFUNCTION(BlueprintCallable, Category="Score")
 		void AddScore(float Amount);
 
-		UFUNCTION(BlueprintCallable, Category="Score")
-		void ResetScore();
+                UFUNCTION(BlueprintCallable, Category="Score")
+                void ResetScore();
+
+                UFUNCTION(BlueprintCallable, Category="Score")
+                float GetScore() const;
 };

--- a/Source/UnrealSpaceInvaders/Core/ShipPlayerController.cpp
+++ b/Source/UnrealSpaceInvaders/Core/ShipPlayerController.cpp
@@ -1,15 +1,45 @@
 #include "ShipPlayerController.h"
 #include "Kismet/GameplayStatics.h"
 #include "PlayerCameraActor.h"
+#include "ScoreWidget.h"
+#include "UnrealSpaceInvaders/Gameplay/PlayerShip.h"
+#include "UnrealSpaceInvaders/Components/ScoreComponent.h"
 
 void AShipPlayerController::BeginPlay()
 {
-	Super::BeginPlay();
-	SetInputMode(FInputModeGameOnly());
-	AActor* CameraActor = UGameplayStatics::GetActorOfClass(GetWorld(), APlayerCameraActor::StaticClass());
-	CameraActor = Cast<class APlayerCameraActor>(CameraActor);
-	if (CameraActor)
-	{
-		SetViewTargetWithBlend(CameraActor);
-	}
+       Super::BeginPlay();
+       SetInputMode(FInputModeGameOnly());
+
+       AActor* CameraActor = UGameplayStatics::GetActorOfClass(GetWorld(), APlayerCameraActor::StaticClass());
+       CameraActor = Cast<APlayerCameraActor>(CameraActor);
+       if (CameraActor)
+       {
+               SetViewTargetWithBlend(CameraActor);
+       }
+
+       if (ScoreWidgetClass)
+       {
+               ScoreWidget = CreateWidget<UScoreWidget>(this, ScoreWidgetClass);
+               if (ScoreWidget)
+               {
+                       ScoreWidget->AddToViewport();
+               }
+       }
+
+       if (APlayerShip* Ship = Cast<APlayerShip>(GetPawn()))
+       {
+               if (UScoreComponent* ScoreComponent = Ship->FindComponentByClass<UScoreComponent>())
+               {
+                       ScoreComponent->OnResourceValueChanged.AddDynamic(this, &AShipPlayerController::OnScoreChanged);
+                       OnScoreChanged(ScoreComponent->GetScore());
+               }
+       }
+}
+
+void AShipPlayerController::OnScoreChanged(float NewScore)
+{
+       if (ScoreWidget)
+       {
+               ScoreWidget->UpdateScore(NewScore);
+       }
 }

--- a/Source/UnrealSpaceInvaders/Core/ShipPlayerController.h
+++ b/Source/UnrealSpaceInvaders/Core/ShipPlayerController.h
@@ -8,8 +8,17 @@
 UCLASS()
 class UNREALSPACEINVADERS_API AShipPlayerController : public APlayerController
 {
-	GENERATED_BODY()
+        GENERATED_BODY()
 
 protected:
-	virtual void BeginPlay() override;
+        virtual void BeginPlay() override;
+
+        UPROPERTY(EditDefaultsOnly, Category="UI")
+        TSubclassOf<class UScoreWidget> ScoreWidgetClass;
+
+        UPROPERTY()
+        UScoreWidget* ScoreWidget;
+
+        UFUNCTION()
+        void OnScoreChanged(float NewScore);
 };

--- a/Source/UnrealSpaceInvaders/ScoreWidget.cpp
+++ b/Source/UnrealSpaceInvaders/ScoreWidget.cpp
@@ -1,0 +1,20 @@
+#include "ScoreWidget.h"
+#include "Components/TextBlock.h"
+
+void UScoreWidget::NativeConstruct()
+{
+    Super::NativeConstruct();
+    if (ScoreText)
+    {
+        ScoreText->SetColorAndOpacity(FSlateColor(FLinearColor::White));
+    }
+}
+
+void UScoreWidget::UpdateScore(float NewScore)
+{
+    if (ScoreText)
+    {
+        const int32 IntScore = FMath::RoundToInt(NewScore);
+        ScoreText->SetText(FText::AsNumber(IntScore));
+    }
+}

--- a/Source/UnrealSpaceInvaders/ScoreWidget.h
+++ b/Source/UnrealSpaceInvaders/ScoreWidget.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Blueprint/UserWidget.h"
+#include "ScoreWidget.generated.h"
+
+UCLASS()
+class UNREALSPACEINVADERS_API UScoreWidget : public UUserWidget
+{
+    GENERATED_BODY()
+
+public:
+    UFUNCTION(BlueprintCallable, Category="Score")
+    void UpdateScore(float NewScore);
+
+protected:
+    virtual void NativeConstruct() override;
+
+    UPROPERTY(meta = (BindWidget))
+    class UTextBlock* ScoreText;
+};

--- a/Source/UnrealSpaceInvaders/UnrealSpaceInvadersGameModeBase.cpp
+++ b/Source/UnrealSpaceInvaders/UnrealSpaceInvadersGameModeBase.cpp
@@ -3,6 +3,7 @@
 #include "AI/Hostile.h"
 #include "UnrealSpaceInvaders/Components/WeaponComponent.h"
 #include "UnrealSpaceInvaders/Components/ScoreComponent.h"
+#include "UnrealSpaceInvaders/Gameplay/PlayerShip.h"
 
 AUnrealSpaceInvadersGameModeBase::AUnrealSpaceInvadersGameModeBase()
 {
@@ -32,7 +33,15 @@ void AUnrealSpaceInvadersGameModeBase::IncreaseDifficulty()
 
 void AUnrealSpaceInvadersGameModeBase::NotifyHostileDestroyed(AHostile* DestroyedHostile) // Custom logic could be added here such as scoring or triggering new waves
 {
-		IncreaseDifficulty();
+               IncreaseDifficulty();
+
+               if (APlayerShip* Ship = Cast<APlayerShip>(UGameplayStatics::GetPlayerPawn(this, 0)))
+               {
+                       if (UScoreComponent* ScoreComp = Ship->FindComponentByClass<UScoreComponent>())
+                       {
+                               ScoreComp->AddScore(10.0f);
+                       }
+               }
 
 }
 


### PR DESCRIPTION
## Summary
- add `ScoreWidget` for HUD display
- allow reading score from `ScoreComponent`
- spawn ScoreWidget in `ShipPlayerController`
- update game mode to award score when hostiles destroyed

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6849d69d641083209a10ea837aa3c362