### PR TITLE
Replace magic numbers with named constants

### DIFF
--- a/Source/UnrealSpaceInvaders/AI/Hostile.cpp
+++ b/Source/UnrealSpaceInvaders/AI/Hostile.cpp
@@ -9,6 +9,17 @@
 #include "UnrealSpaceInvaders/Projectile.h"
 #include "UnrealSpaceInvaders/UnrealSpaceInvadersGameModeBase.h"
 
+namespace
+{
+	constexpr float WeaponSpawnOffsetZ = -100.0f;
+	constexpr float HostileCollisionExtent = 51.0f;
+	constexpr float HostileMoveInterval = 0.05f;
+	constexpr double MovementDirectionFlip = -1.0;
+	constexpr float DefaultDifficultyMultiplier = 1.0f;
+	constexpr float FireDelayMinSeconds = 2.0f;
+	constexpr float FireDelayMaxSeconds = 5.0f;
+}
+
 AHostile::AHostile()
 {
 	HostileCollision = CreateDefaultSubobject<UBoxComponent>(TEXT("HostileCollision"));
@@ -16,7 +27,7 @@ AHostile::AHostile()
         WeaponComponent = CreateDefaultSubobject<UWeaponComponent>(TEXT("WeaponComponent"));
         if (WeaponComponent)
         {
-                WeaponComponent->SpawnOffset = FVector(0.0f, 0.0f, -100.0f);
+                WeaponComponent->SpawnOffset = FVector(0.0f, 0.0f, WeaponSpawnOffsetZ);
                 WeaponComponent->bFireUpwards = false;
         }
 
@@ -26,7 +37,7 @@ AHostile::AHostile()
 
 	SetRootComponent(HostileCollision);
 	HostileMesh->SetupAttachment(HostileCollision);
-	HostileCollision->SetBoxExtent(FVector(51.0, 51.0, 51.0));
+	HostileCollision->SetBoxExtent(FVector(HostileCollisionExtent, HostileCollisionExtent, HostileCollisionExtent));
 	HostileCollision->OnComponentBeginOverlap.AddDynamic(this, &ThisClass::ProjectileOverlap);
 	NiagaraEffect = LoadObject<UNiagaraSystem>(nullptr, TEXT("/Game/Hostiles/VFX/NS_DestroyEffect"));
 	//	BlastSound = LoadObject<USoundBase>(nullptr, TEXT("/Game/Hostiles/Sound/SW_DestroyHostile"));
@@ -43,7 +54,7 @@ void AHostile::BeginPlay()
 
 	if (FTimerHandle MoveTimer; !MoveTimer.IsValid())
 	{
-		GetWorldTimerManager().SetTimer(MoveTimer, this, &ThisClass::Move, 0.05, true);
+		GetWorldTimerManager().SetTimer(MoveTimer, this, &ThisClass::Move, HostileMoveInterval, true);
 	}
 }
 
@@ -88,25 +99,25 @@ void AHostile::ChangeMovementDirection()
 	UGameplayStatics::GetAllActorsOfClass(GetWorld(), StaticClass(), OutActors);
 	for (AActor* HostileActor : OutActors)
 	{
-		if
-		(AHostile* HostileActorDude = Cast<AHostile>(HostileActor))
-		{
-			HostileActorDude->MoveDirection *= -1.0;
-		}
+			if
+			(AHostile* HostileActorDude = Cast<AHostile>(HostileActor))
+			{
+				HostileActorDude->MoveDirection *= MovementDirectionFlip;
+			}
 	}
 }
 
 void AHostile::Move()
 {
        AUnrealSpaceInvadersGameModeBase* GM = GetWorld() ? GetWorld()->GetAuthGameMode<AUnrealSpaceInvadersGameModeBase>() : nullptr;
-       const float Multiplier = GM ? GM->DifficultyMultiplier : 1.0f;
+       const float Multiplier = GM ? GM->DifficultyMultiplier : DefaultDifficultyMultiplier;
        const FVector NewLocation = GetActorLocation() + FVector(0.0, MoveDirection * MoveSpeed * Multiplier, 0.0);
        SetActorLocation(NewLocation);
 }
 
 void AHostile::BeginFire()
 {
-	const float FireDelay = FMath::RandRange(2.0, 5.0);
+	const float FireDelay = FMath::RandRange(FireDelayMinSeconds, FireDelayMaxSeconds);
 	if (!ReloadTimerHandle.IsValid())
 	{
 		GetWorldTimerManager().SetTimer(ReloadTimerHandle, this, &AHostile::SpawnProjectile, FireDelay, false);

--- a/Source/UnrealSpaceInvaders/AI/Hostile.h
+++ b/Source/UnrealSpaceInvaders/AI/Hostile.h
@@ -21,8 +21,12 @@ class UNREALSPACEINVADERS_API AHostile : public AActor
 public:
         AHostile();
 
+       static constexpr float DefaultMoveSpeed = 1.0f;
+       static constexpr double DefaultMoveDirection = -1.0;
+       static constexpr int32 DefaultProjectileMax = 8;
+
        UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Movement")
-       float MoveSpeed = 1.0f;
+       float MoveSpeed = DefaultMoveSpeed;
 
        FORCEINLINE class UWeaponComponent* GetWeaponComponent() const { return WeaponComponent; }
 
@@ -49,9 +53,9 @@ protected:
         TSubclassOf<AProjectile> ActorProjectile;
 
 	FTimerHandle ReloadTimerHandle;
-	double MoveDirection = -1.0;
+	double MoveDirection = DefaultMoveDirection;
 	int32 ProjectileCounter;
-	const int32 ProjectileMax = 8;
+	const int32 ProjectileMax = DefaultProjectileMax;
 
 	UFUNCTION()
 	void ProjectileOverlap(UPrimitiveComponent* OverlappedComponent,

--- a/Source/UnrealSpaceInvaders/AI/HostileSwarm.cpp
+++ b/Source/UnrealSpaceInvaders/AI/HostileSwarm.cpp
@@ -3,6 +3,15 @@
 #include "Hostile.h"
 #include "Kismet/GameplayStatics.h"
 
+namespace
+{
+	constexpr float HostileCheckIntervalSeconds = 2.0f;
+	constexpr int32 HostileCountZ = 5;
+	constexpr int32 HostileCountY = 11;
+	constexpr double HostileSpacing = 120.0;
+	constexpr int32 HostileStartZ = 1;
+}
+
 void AHostileSwarm::BeginPlay()
 {
 	Super::BeginPlay();
@@ -10,17 +19,17 @@ void AHostileSwarm::BeginPlay()
 	FTimerHandle CheckHostilesTimer;
 	if (!CheckHostilesTimer.IsValid())
 	{
-		GetWorldTimerManager().SetTimer(CheckHostilesTimer, this, &AHostileSwarm::CheckHostiles, 2.0, true);
+		GetWorldTimerManager().SetTimer(CheckHostilesTimer, this, &AHostileSwarm::CheckHostiles, HostileCheckIntervalSeconds, true);
 	}
 }
 
 void AHostileSwarm::SpawnHostiles() const
 {
 	const FVector SpawnLocation = GetActorLocation();
-	int32 CountZ = 5;
-	int32 CountY = 11;
-	double Spacing = 120.0;
-	for (int32 z = 1; z < CountZ; z++)
+	int32 CountZ = HostileCountZ;
+	int32 CountY = HostileCountY;
+	double Spacing = HostileSpacing;
+	for (int32 z = HostileStartZ; z < CountZ; z++)
 	{
 		for (int32 y = 0; y < CountY; y++)
 		{

--- a/Source/UnrealSpaceInvaders/Components/EntityResource.h
+++ b/Source/UnrealSpaceInvaders/Components/EntityResource.h
@@ -19,11 +19,14 @@ public:
 protected:
 	virtual void BeginPlay() override;
 
+	static constexpr float DefaultInitialValue = 100.0f;
+	static constexpr float DefaultMaxValue = 100.0f;
+
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Resource", meta=(AllowPrivateAccess="true"))
-	float InitialValue = 100.0f;
+	float InitialValue = DefaultInitialValue;
 
 	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category="Resource", meta=(AllowPrivateAccess="true"))
-	float MaxValue = 100.0f;
+	float MaxValue = DefaultMaxValue;
 
 	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category="Resource", meta=(AllowPrivateAccess="true"))
 	float CurrentValue;

--- a/Source/UnrealSpaceInvaders/Components/WeaponComponent.cpp
+++ b/Source/UnrealSpaceInvaders/Components/WeaponComponent.cpp
@@ -4,14 +4,23 @@
 #include "UnrealSpaceInvaders/Projectile.h"
 #include "UnrealSpaceInvaders/Gameplay/PlayerShip.h"
 
+namespace
+{
+	constexpr float DefaultFireRate = 1.0f;
+	constexpr float DefaultProjectileSpeed = 500.0f;
+	constexpr float DefaultProjectileMaxSpeed = 500.0f;
+	constexpr float DefaultProjectileGravityScale = 0.0f;
+	constexpr float DefaultSpawnOffsetZ = 50.0f;
+}
+
 UWeaponComponent::UWeaponComponent()
 {
-    FireRate = 1.0f; // One shot per second
-    ProjectileSpeed = 500.0f; // Projectile speed
-    ProjectileMaxSpeed = 500.0f;
+    FireRate = DefaultFireRate; // One shot per second
+    ProjectileSpeed = DefaultProjectileSpeed; // Projectile speed
+    ProjectileMaxSpeed = DefaultProjectileMaxSpeed;
     bRotationFollowsVelocity = true;
-    ProjectileGravityScale = 0.0f;
-    SpawnOffset = FVector(0.0f, 0.0f, 50.0f); // Offset from the actor's center
+    ProjectileGravityScale = DefaultProjectileGravityScale;
+    SpawnOffset = FVector(0.0f, 0.0f, DefaultSpawnOffsetZ); // Offset from the actor's center
     bFireUpwards = true; // Firing upwards by default
 }
 

--- a/Source/UnrealSpaceInvaders/Environment/TheWall.cpp
+++ b/Source/UnrealSpaceInvaders/Environment/TheWall.cpp
@@ -1,6 +1,13 @@
 #include "TheWall.h"
 #include "UnrealSpaceInvaders/Projectile.h"
 
+namespace
+{
+	constexpr int32 WallCount = 20;
+	constexpr double WallSpacing = 10.0;
+	constexpr double WallScale = 0.1;
+}
+
 void ATheWall::BeginPlay()
 {
 	Super::BeginPlay();
@@ -10,8 +17,8 @@ void ATheWall::BeginPlay()
 void ATheWall::ConstructWall()
 {
 
-	int32 Count = 20;
-	double Spacing = 10.0;
+	int32 Count = WallCount;
+	double Spacing = WallSpacing;
 	int32 Row;
 	int32 Column;
 
@@ -27,9 +34,9 @@ void ATheWall::ConstructWall()
 				{
 					WallComponent->SetStaticMesh(WallMesh);
 					WallComponent->SetupAttachment(RootComponent);
-					WallComponent->SetRelativeTransform(
-						FTransform(FRotator::ZeroRotator, FVector(0.0, Column * Spacing, Row * Spacing),
-						           FVector(0.1, 0.1, 0.1)));
+						WallComponent->SetRelativeTransform(
+							FTransform(FRotator::ZeroRotator, FVector(0.0, Column * Spacing, Row * Spacing),
+							           FVector(WallScale, WallScale, WallScale)));
 					WallComponent->RegisterComponent();
 					WallComponent->OnComponentBeginOverlap.AddDynamic(this, &ThisClass::WallOverlap);
 				}

--- a/Source/UnrealSpaceInvaders/Gameplay/PlayerShip.cpp
+++ b/Source/UnrealSpaceInvaders/Gameplay/PlayerShip.cpp
@@ -10,6 +10,13 @@
 #include "UnrealSpaceInvaders/Components/WeaponComponent.h"
 #include "UnrealSpaceInvaders/Components/ScoreComponent.h"
 
+namespace
+{
+	constexpr float DefaultWeaponSpawnOffsetZ = 100.0f;
+	constexpr float DefaultCollisionSphereRadius = 50.0f;
+	constexpr int32 DefaultInputMappingPriority = 0;
+}
+
 APlayerShip::APlayerShip()
 {
 	ShipCollision = CreateDefaultSubobject<USphereComponent>(TEXT("ShipCollision"));
@@ -20,7 +27,7 @@ APlayerShip::APlayerShip()
 
 	if (WeaponComponent)
         {
-                WeaponComponent->SpawnOffset = FVector(0.0f, 0.0f, 100.0f);
+                WeaponComponent->SpawnOffset = FVector(0.0f, 0.0f, DefaultWeaponSpawnOffsetZ);
                 WeaponComponent->bFireUpwards = true;
         }
 
@@ -30,7 +37,7 @@ APlayerShip::APlayerShip()
     check(ScoreComponent);
 
 	SetRootComponent(ShipCollision);
-	ShipCollision->SetSphereRadius(50.0);
+	ShipCollision->SetSphereRadius(DefaultCollisionSphereRadius);
 	ShipCollision->SetCollisionProfileName(TEXT("Pawn"));
 	ShipCollision->OnComponentBeginOverlap.AddDynamic(this, &APlayerShip::PlayerShipOverlap);
 	ShipMesh->SetupAttachment(ShipCollision);
@@ -44,7 +51,7 @@ void APlayerShip::BeginPlay()
                 if (UEnhancedInputLocalPlayerSubsystem* Subsystem = ULocalPlayer::GetSubsystem<
                         UEnhancedInputLocalPlayerSubsystem>(PlayerController->GetLocalPlayer()))
                 {
-                        Subsystem->AddMappingContext(ShipInputMappingContext, 0);
+                        Subsystem->AddMappingContext(ShipInputMappingContext, DefaultInputMappingPriority);
                 }
         }
         if (WeaponComponent)

--- a/Source/UnrealSpaceInvaders/Gameplay/PlayerShip.h
+++ b/Source/UnrealSpaceInvaders/Gameplay/PlayerShip.h
@@ -29,6 +29,8 @@ public:
 protected:
 	virtual void BeginPlay() override;
 
+	static constexpr float DefaultReloadTime = 0.5f;
+
 	UPROPERTY(EditDefaultsOnly)
 	TObjectPtr<USphereComponent> ShipCollision;
 
@@ -68,7 +70,7 @@ protected:
 
         bool bCanAttack = true;
 
-	float ReloadTime = 0.5;
+	float ReloadTime = DefaultReloadTime;
 
 	void Move(const FInputActionValue& Value);
 

--- a/Source/UnrealSpaceInvaders/Projectile.cpp
+++ b/Source/UnrealSpaceInvaders/Projectile.cpp
@@ -7,6 +7,18 @@
 #include "Environment/TheWall.h"
 #include "GameFramework/ProjectileMovementComponent.h"
 
+namespace
+{
+	constexpr float ProjectileScaleX = 0.4f;
+	constexpr float ProjectileScaleY = 0.4f;
+	constexpr float ProjectileScaleZ = 0.6f;
+	constexpr float ProjectileCapsuleHalfHeight = 40.0f;
+	constexpr float ProjectileCapsuleRadius = 22.0f;
+	constexpr float ProjectileInitialSpeed = 1000.0f;
+	constexpr float ProjectileMaxSpeed = 1000.0f;
+	constexpr float ProjectileGravityScale = 0.0f;
+}
+
 
 AProjectile::AProjectile()
 {
@@ -20,13 +32,13 @@ AProjectile::AProjectile()
 
         SetRootComponent(ProjectileCollisionCapsule);
         ProjectileMesh->SetupAttachment(ProjectileCollisionCapsule);
-        ProjectileMesh->SetRelativeScale3D(FVector(0.4, 0.4, 0.6));
-        ProjectileCollisionCapsule->SetCapsuleHalfHeight(40.0);
-        ProjectileCollisionCapsule->SetCapsuleRadius(22.0);
-        ProjectileMovement->InitialSpeed = 1000.0f;
-        ProjectileMovement->MaxSpeed = 1000.0f;
+        ProjectileMesh->SetRelativeScale3D(FVector(ProjectileScaleX, ProjectileScaleY, ProjectileScaleZ));
+        ProjectileCollisionCapsule->SetCapsuleHalfHeight(ProjectileCapsuleHalfHeight);
+        ProjectileCollisionCapsule->SetCapsuleRadius(ProjectileCapsuleRadius);
+        ProjectileMovement->InitialSpeed = ProjectileInitialSpeed;
+        ProjectileMovement->MaxSpeed = ProjectileMaxSpeed;
         ProjectileMovement->bRotationFollowsVelocity = true;
-        ProjectileMovement->ProjectileGravityScale = 0.0f;
+        ProjectileMovement->ProjectileGravityScale = ProjectileGravityScale;
         ProjectileCollisionCapsule->OnComponentBeginOverlap.AddDynamic(this, &ThisClass::ProjectileOverlap);
 }
 

--- a/Source/UnrealSpaceInvaders/UnrealSpaceInvadersGameModeBase.cpp
+++ b/Source/UnrealSpaceInvaders/UnrealSpaceInvadersGameModeBase.cpp
@@ -5,43 +5,53 @@
 #include "UnrealSpaceInvaders/Components/ScoreComponent.h"
 #include "UnrealSpaceInvaders/Gameplay/PlayerShip.h"
 
+namespace
+{
+	constexpr float DefaultDifficultyMultiplier = 1.0f;
+	constexpr float DifficultyIncreaseStep = 0.1f;
+	constexpr float HostileMoveSpeedMultiplier = 1.1f;
+	constexpr float MinFireRate = 0.1f;
+	constexpr float FireRateMultiplier = 0.9f;
+	constexpr int32 DefaultPlayerIndex = 0;
+	constexpr float HostileScoreValue = 10.0f;
+}
+
 AUnrealSpaceInvadersGameModeBase::AUnrealSpaceInvadersGameModeBase()
 {
-       DifficultyMultiplier = 1.0f;
+       DifficultyMultiplier = DefaultDifficultyMultiplier;
 }
 
 
 void AUnrealSpaceInvadersGameModeBase::IncreaseDifficulty()
 {
-	DifficultyMultiplier += 0.1f;
+	DifficultyMultiplier += DifficultyIncreaseStep;
 
         TArray<AActor*> HostileActors;
        UGameplayStatics::GetAllActorsOfClass(GetWorld(), AHostile::StaticClass(), HostileActors);
 
        for (AActor* Actor : HostileActors)
        {
-               if (AHostile* Hostile = Cast<AHostile>(Actor))
-               {
-                       Hostile->MoveSpeed *= 1.1f;
-                       if (UWeaponComponent* Weapon = Hostile->GetWeaponComponent())
-                       {
-                               Weapon->FireRate = FMath::Max(0.1f, Weapon->FireRate * 0.9f);
-                       }
-               }
-       }
+	               if (AHostile* Hostile = Cast<AHostile>(Actor))
+	               {
+	                       Hostile->MoveSpeed *= HostileMoveSpeedMultiplier;
+	                       if (UWeaponComponent* Weapon = Hostile->GetWeaponComponent())
+	                       {
+	                               Weapon->FireRate = FMath::Max(MinFireRate, Weapon->FireRate * FireRateMultiplier);
+	                       }
+	               }
+	       }
 }
 
 void AUnrealSpaceInvadersGameModeBase::NotifyHostileDestroyed(AHostile* DestroyedHostile) // Custom logic could be added here such as scoring or triggering new waves
 {
                IncreaseDifficulty();
 
-               if (APlayerShip* Ship = Cast<APlayerShip>(UGameplayStatics::GetPlayerPawn(this, 0)))
-               {
-                       if (UScoreComponent* ScoreComp = Ship->FindComponentByClass<UScoreComponent>())
-                       {
-                               ScoreComp->AddScore(10.0f);
-                       }
-               }
+	               if (APlayerShip* Ship = Cast<APlayerShip>(UGameplayStatics::GetPlayerPawn(this, DefaultPlayerIndex)))
+	               {
+	                       if (UScoreComponent* ScoreComp = Ship->FindComponentByClass<UScoreComponent>())
+	                       {
+	                               ScoreComp->AddScore(HostileScoreValue);
+	                       }
+	               }
 
 }
-


### PR DESCRIPTION
### Motivation
- Centralize gameplay tuning values to improve readability and make balancing easier by replacing hard-coded literals with named constants across the codebase.
- Reduce repeated magic numbers and provide clear defaults for resources, weapon/projectile behavior, hostile AI, swarm spawning, wall construction, and game difficulty.

### Description
- Introduced constexpr named defaults and swapped literal initializers in `EntityResource`, `WeaponComponent`, `Projectile`, `PlayerShip`, `TheWall`, `Hostile`, `HostileSwarm`, and `UnrealSpaceInvadersGameModeBase` to use those constants.
- Replaced inline numbers for spawn offsets, speeds, scales, sizes, timers, movement/firing parameters, swarm dimensions, and difficulty tuning with centralized constants to make intent explicit.
- Updated hostiles and game mode logic to use new constants for difficulty increments, move speed multiplier, minimum fire rate, and scoring.
- Kept existing runtime behavior unchanged while making parameters easier to tune by editing the newly introduced constants.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698325f717b08320b0fb300c5ce934c3)